### PR TITLE
Separated Braintree credentials registering

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,19 +9,16 @@ use Illuminate\Support\ServiceProvider;
 class AppServiceProvider extends ServiceProvider
 {
     /**
-     * Configure BrainTree.
+     * Bootstrap the application services.
      *
      * @return void
      */
     public function boot()
     {
-        Braintree_Configuration::environment(env('BRAINTREE_ENV'));
-        Braintree_Configuration::merchantId(env('BRAINTREE_MERCHANT_ID'));
-        Braintree_Configuration::publicKey(env('BRAINTREE_PUBLIC_KEY'));
-        Braintree_Configuration::privateKey(env('BRAINTREE_PRIVATE_KEY'));
+        //
     }
 
-/**
+    /**
      * Register any application services.
      *
      * @return void

--- a/app/Providers/BraintreeServiceProvider.php
+++ b/app/Providers/BraintreeServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class BraintreeServiceProvider extends ServiceProvider
+{
+    /**
+     * Register Braintree credentials.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Braintree_Configuration::environment(env('BRAINTREE_ENV'));
+        Braintree_Configuration::merchantId(env('BRAINTREE_MERCHANT_ID'));
+        Braintree_Configuration::publicKey(env('BRAINTREE_PUBLIC_KEY'));
+        Braintree_Configuration::privateKey(env('BRAINTREE_PRIVATE_KEY'));
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -172,6 +172,11 @@ return [
          */
         PhantomPdf\Laravel\LaravelServiceProvider::class,
 
+        /*
+         * Braintree
+         */
+        App\Providers\BraintreeServiceProvider::class,
+
     ],
 
     /*


### PR DESCRIPTION
Separated Braintree credentials registering from AppServiceProvider to
BraintreeServiceProvider.

This **does not** change logic. This is **just** for aesthetic purposes.